### PR TITLE
Change issue B.1 to allow for optional omission of mount-point in parent module

### DIFF
--- a/draft-ietf-netmod-schema-mount.org
+++ b/draft-ietf-netmod-schema-mount.org
@@ -580,8 +580,7 @@ line):
 
 Each entry in the "mount-point" list is currently identified by two
 keys, namely YANG module name and mount point name. An alternative is
-to use a schema node identifier of the mount point instead of just its
-name.
+to use a schema node identifier of the mount point as the single key.
 
 For example, the "schema-mounts" data for NI (^exni^) would be changed
 as follows (the "schema" list doesn't change):

--- a/draft-ietf-netmod-schema-mount.org
+++ b/draft-ietf-netmod-schema-mount.org
@@ -580,7 +580,8 @@ line):
 
 Each entry in the "mount-point" list is currently identified by two
 keys, namely YANG module name and mount point name. An alternative is
-to use a schema node identifier of the mount point as the single key.
+to use a schema node identifier of the mount point instead of just its
+name.
 
 For example, the "schema-mounts" data for NI (^exni^) would be changed
 as follows (the "schema" list doesn't change):
@@ -589,22 +590,17 @@ as follows (the "schema" list doesn't change):
 
 This change would have several advantages:
 
-- no YANG extension is needed
-
-- parent modules needn't be searched for mount points, these are
-  specified explicitly
-
 - the schema mount mechanism becomes even closer to augments, which
   may simplify implementation
 
 - if a mount point appears inside a grouping, then a different mounted
   schema can be used for each use of the grouping.
 
-The disadvantage is that a mount point cannot be formally specified in
-the parent module. However, it is unclear how this could be useful
-because a mount point means nothing without corresponding data under
-"schema-mounts". For human readers, the intentions of the parent
-module's author regarding mount point can be placed in descriptions.
+- the same mount point name may be used multiple times in the same
+  module, although it is unclear if this is useful or not.
+
+- it optionally allows for use of mount without use of the mount-point
+  extension. 
 
 ** Defining the "mount-point" Extension in a Separate Module
 

--- a/draft-ietf-netmod-schema-mount.org
+++ b/draft-ietf-netmod-schema-mount.org
@@ -595,9 +595,6 @@ This change would have several advantages:
 - if a mount point appears inside a grouping, then a different mounted
   schema can be used for each use of the grouping.
 
-- the same mount point name may be used multiple times in the same
-  module, although it is unclear if this is useful or not.
-
 - it optionally allows for use of mount without use of the mount-point
   extension. 
 


### PR DESCRIPTION
This change alters Open Issue B.1 to use path in place of simple name to identify
 a mount point within a module.

It also makes extension less mount points an *option* vs the only
option.  Many in the WG have already voiced their view on the importance
of the use of the extension when designing modules that contain mount
point.  And removing the ability to include the extension would against
this apparent consensus position.